### PR TITLE
fix: Update starterIndex.ts

### DIFF
--- a/src/starterIndex.ts
+++ b/src/starterIndex.ts
@@ -68,13 +68,13 @@ export default class MyPlugin extends Plugin {
 
     onLayoutReady(): void {
         if (this.app.workspace.getLeavesOfType(VIEW_TYPE).length) {
-            this.app.workspace.rightSplit.collapsed && this.app.workspace.rightSplit.toggle(true);
+            this.app.workspace.rightSplit.collapsed && this.app.workspace.rightSplit.toggle();
             return;
         }
         this.app.workspace.getRightLeaf(false)?.setViewState({
             type: VIEW_TYPE,
         });
-        this.app.workspace.rightSplit.collapsed && this.app.workspace.rightSplit.toggle(true);
+        this.app.workspace.rightSplit.collapsed && this.app.workspace.rightSplit.toggle();
     }
 
     onunload() {


### PR DESCRIPTION
Now the latest obsidian API receives 0 arguments.

In `obsidian/obsidian.d.ts` line 4891:
```typescript
/**
 * @public
 */
export class WorkspaceSidedock extends WorkspaceSplit {

    /** @public */
    collapsed: boolean;

    /** @public */
    toggle(): void;
    /** @public */
    collapse(): void;
    /** @public */
    expand(): void;

}
```
